### PR TITLE
List selected regions/tiles

### DIFF
--- a/src/togos/minecraft/maprend/tiles.css
+++ b/src/togos/minecraft/maprend/tiles.css
@@ -17,6 +17,14 @@ a.tile {
 a.tile:hover {
 	border: 1px solid rgba(255,255,255,0.5);
 }
+a.selected:before {
+	content: ' ';
+	display: block;
+	width: 100%;
+	height: 100%;
+	opacity: 0.7;
+	background-color: black;
+}
 
 .notes, .scales-nav {
 	color: cornflowerblue;
@@ -35,4 +43,24 @@ p.notes, .scales-nav p, .scales-nav li {
 }
 .scales-nav p, .scales-nav ul, .scales-nav ul li {
 	display: inline-block;
+}
+
+#selectedTiles {
+	background-color: rgba(255, 255, 255, 0.7);
+	display: flex;
+	flex-direction: column;
+	height: 100%;
+	padding: 0 1em;
+	position: fixed;
+	right: 0;
+	top: 0;
+	width: 10em;
+	z-index: 1;
+}
+#selectedTiles h1 {
+	font-size: 1.2em;
+}
+#selectedTiles textarea {
+	flex-grow: 1;
+	width: 100%;
 }

--- a/src/togos/minecraft/maprend/tiles.js
+++ b/src/togos/minecraft/maprend/tiles.js
@@ -1,0 +1,46 @@
+var selectedTiles = {};
+
+function toggleTile(tileName) {
+	$(`a[name='${tileName}']`).toggleClass('selected');
+	if (tileName in selectedTiles) {
+		delete selectedTiles[tileName];
+	} else {
+		selectedTiles[tileName] = true;
+	}
+	updateTextList();
+}
+
+function updateTextList() {
+	var text = '';
+	for (var tileName in selectedTiles) {
+		text += tileName + '\n';
+	}
+
+	var tilesListEl = $('#selectedTiles');
+	$('#selectedTiles textarea').val(text);
+	if (text) {
+		tilesListEl.show();
+	} else {
+		tilesListEl.hide();
+	}
+}
+
+function replaceSelected(newSelectedTiles) {
+	$('.selected').toggleClass('selected');
+	selectedTiles = {};
+	for (var i = 0; i < newSelectedTiles.length; i++) {
+		var tileName = newSelectedTiles[i];
+		var matchedTiles = $(`a[name='${tileName}']`);
+		if (matchedTiles.length) {
+			matchedTiles.toggleClass('selected');
+			selectedTiles[tileName] = true;
+		}
+		
+	}
+}
+
+$(function() {
+	$('#selectedTiles textarea').on('input', function() {
+		replaceSelected($(this).val().trim().split(/\s+/));
+	});
+});


### PR DESCRIPTION
I'm using TMCMR to figure out which region files to delete from our map so we can re-explore nearby territory and find new stuff from the 1.11 update (llamas, woodland mansions). It's very useful, since the images match the region files, but I added a little javascript so you can click to toggle regions, and get a list of the region IDs.

Demo: http://www.markfickett.com/tmp/tmcmr/tiles.1-8.html#r.-7.-3 then click on some tiles. You can also copy/paste the list of regions (if you paste in a new list it updates the highlighted tiles).

I know this is addressing my specific use case; so here it is in case it's useful, but no worries if it isn't something you want to add to your map generator.

This builds on my other pull request. (They should merge cleanly. Since the other one is so small I'm not worrying about splitting it out more separately; I'm not sure if there's a cleaner way to set this up on Github.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/togos/tmcmr/26)
<!-- Reviewable:end -->
