### PR TITLE
Multi-threaded renderer

### DIFF
--- a/src/togos/minecraft/maprend/RegionRenderer.java
+++ b/src/togos/minecraft/maprend/RegionRenderer.java
@@ -412,21 +412,16 @@ public class RegionRenderer
                     numThreads = numRegions;
                 }
                 
-                int curIndex = -1;
-                int regionInterval = numRegions / numThreads;
-                
+                int regionInterval = numRegions / numThreads;      
                 RenderThread[] renderThreads = new RenderThread[numThreads];
                 
                 for (int i = 0; i < numThreads; i++) {
                     renderThreads[i] = new RenderThread(rm.regions, 0, 0, outputDir, force);
-                    renderThreads[i].startIndex = curIndex + 1;
-                    curIndex += regionInterval;
-                    if (curIndex < numRegions) {
-                        renderThreads[i].endIndex = curIndex;
-                    } else {
+                    renderThreads[i].startIndex = regionInterval * i;
+                    renderThreads[i].endIndex = regionInterval * (i + 1) - 1;
+                    if (i == numThreads - 1) {
                         renderThreads[i].endIndex = numRegions - 1;
                     }
-                    System.out.println("Thread " + i + " starting on region " + renderThreads[i].startIndex + " and ending on " + renderThreads[i].endIndex);
                     renderThreads[i].start();
                 }
                 

--- a/src/togos/minecraft/maprend/RegionRenderer.java
+++ b/src/togos/minecraft/maprend/RegionRenderer.java
@@ -406,11 +406,35 @@ public class RegionRenderer
                     System.err.println("Warning: no regions found!");
 		}
 		
-		for( Region r : rm.regions ) {
-                    Thread rThread = new RenderThread(r, outputDir, force);
-                    rThread.start();
+                
+                int numRegions = rm.regions.size();
+                int curRegion = 0;
+                
+		while (curRegion != numRegions) {
+                    
+                    //first thread setup
+                    Thread rThread1 = new RenderThread(rm.regions.get(curRegion), outputDir, force);
+                    rThread1.start();
+                    curRegion++;
+                    System.out.println("First thread started...");
+                    
+                    //second thread setup (if needed)
+                    if (curRegion != numRegions) {
+                        Thread rThread2 = new RenderThread(rm.regions.get(curRegion), outputDir, force);
+                        rThread2.start();
+                        curRegion++;
+                        
+                        System.out.println("Second thread started...");
+                        
+                        try {
+                            rThread2.join();
+                        } catch (InterruptedException e) {
+                            e.printStackTrace();
+                        }
+                    }
+                    
                     try {
-                        rThread.join();
+                        rThread1.join();
                     } catch (InterruptedException e) {
                         e.printStackTrace();
                     }


### PR DESCRIPTION
This patch enables threaded rendering, ie. the ability to use multiple processor cores to render the final map. Specifially, only the image file generation is threaded, but this is where most of the time is spent. Performance scales very well, nearly linearly with the number of processor cores. 

I have added a command line option to allow specifying the number of threads to use. If omitted, the renderer defaults to using 2 threads.