### PR TITLE
Add support of old MCRegion (.mcr) format

### DIFF
--- a/src/main/java/togos/minecraft/maprend/McRegionChunkData.java
+++ b/src/main/java/togos/minecraft/maprend/McRegionChunkData.java
@@ -1,0 +1,69 @@
+package togos.minecraft.maprend;
+
+import java.util.Map;
+
+import org.jnbt.ByteArrayTag;
+import org.jnbt.CompoundTag;
+import org.jnbt.IntTag;
+
+public class McRegionChunkData extends McRegionMiniChunkData
+{
+	public McRegionChunkData( long px, long py, long pz, int w, int h, int d ) {
+		super(px,py,pz,w,h,d);
+	}
+
+	/*
+	public final int height = 128; // Y/+up/-down
+	public final int depth  =  16; // Z/+west/-east
+	public final int width  =  16; // X/+south/-north
+
+	            (N, -x)
+	               |
+	               |
+	               |
+	               |
+	(W, +z)--------0---------(E, -z)
+	               |
+	               |
+	               |
+   	               |
+	            (S, +x)
+	*/
+
+	public byte[] skyLightData   = new byte[(height*depth*width+1)/2];
+	public byte[] blockLightData = new byte[(height*depth*width+1)/2];
+	public byte[] lightHeightData = new byte[depth*width];
+	public boolean terrainPopulated = false;
+
+	//// Sky light ////
+
+	public void setSkyLight( int x, int y, int z, int value ) {
+		putNybble(skyLightData, blockIndex(x,y,z), value);
+	}
+
+	//// Light height ////
+
+	public void setLightHeight( int x, int z, int height ) {
+		lightHeightData[z*width+x] = (byte)(height);
+	}
+
+	public static McRegionChunkData fromTag( CompoundTag t ) {
+		Map m = t.getValue();
+		IntTag xPos = (IntTag)m.get( "xPos" );
+		IntTag zPos = (IntTag)m.get( "zPos" );
+
+		McRegionChunkData cd = new McRegionChunkData(
+			16*xPos.getValue().intValue(), 0, 16*zPos.getValue().intValue(),
+			16, 128, 16
+		);
+
+		cd.blocks = ((ByteArrayTag)m.get("Blocks")).getValue();
+		cd.block_data = ((ByteArrayTag)m.get("Data")).getValue();
+		cd.skyLightData = ((ByteArrayTag)m.get("SkyLight")).getValue();
+		cd.blockLightData = ((ByteArrayTag)m.get("BlockLight")).getValue();
+		cd.lightHeightData = ((ByteArrayTag)m.get("HeightMap")).getValue();
+		// TODO: this part
+		//cd.tileEntityData = ((CompoundTag)m.get("TileEntities")).getValue();
+		return cd;
+	}
+}

--- a/src/main/java/togos/minecraft/maprend/McRegionMiniChunkData.java
+++ b/src/main/java/togos/minecraft/maprend/McRegionMiniChunkData.java
@@ -1,0 +1,92 @@
+package togos.minecraft.maprend;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class McRegionMiniChunkData
+{
+	/**
+	 * X,Y,Z coordinates (in blocks a.k.a. world units a.k.a. meters)
+	 * of the bottom northeast corner of the chunk within the world.
+	 */
+	public final long posX, posY, posZ;
+	public final int width, height, depth;
+
+	public byte[] blocks;
+	public byte[] block_data;
+	public List tileEntityData = new ArrayList();
+
+	public McRegionMiniChunkData( long px, long py, long pz, int width, int height, int depth ) {
+		this.posX = px;
+		this.posY = py;
+		this.posZ = pz;
+		this.width = width;
+		this.height = height;
+		this.depth = depth;
+		this.blocks = new byte[height*depth*width];
+		this.block_data = new byte[(height*depth*width+1)/2];
+	}
+
+	/*
+	 * Return the
+	 * X,Y,Z coordinates (in blocks a.k.a. world units a.k.a. meters)
+	 * of the bottom northeast corner of the chunk within the world.
+	 */
+	public long getChunkPositionX() { return posX; }
+	public long getChunkPositionY() { return posY; }
+	public long getChunkPositionZ() { return posZ; }
+
+	public int getChunkWidth() {  return width;  }
+	public int getChunkHeight() { return height; }
+	public int getChunkDepth() {  return depth;  }
+
+	protected int blockIndex( int x, int y, int z ) {
+		return y + z*height + x*depth*height;
+	}
+
+	protected void putNybble( byte[] data, int index, int value ) {
+		int byteIndex = index>>1;
+		byte oldValue = data[byteIndex];
+		if( (index & 0x1) == 0 ) {
+			data[ byteIndex ] = (byte)((oldValue & 0xF0) | (value & 0x0F));
+		} else {
+			data[ byteIndex ] = (byte)((oldValue & 0x0F) | ((value<<4) & 0xF0));
+		}
+	}
+
+	protected byte getNybble( byte[] data, int index ) {
+		int byteIndex = index>>1;
+		if( (index & 0x1) == 0 ) {
+			return (byte)((data[ byteIndex ] >> 4) & 0x0F);
+		} else {
+			return (byte)((data[ byteIndex ] >> 0) & 0x0F);
+		}
+	}
+
+	//// Block ////
+
+	public byte getBlock( int x, int y, int z ) {
+		return blocks[ blockIndex(x,y,z) ];
+	}
+
+	public void setBlockNumber( int x, int y, int z, byte blockNum ) {
+		blocks[ blockIndex(x,y,z) ] = blockNum;
+	}
+
+	public byte getBlockExtraBits( int x, int y, int z ) {
+		return getNybble( block_data, blockIndex(x,y,z) );
+	}
+
+	public void setBlockExtraBits( int x, int y, int z, byte value ) {
+		putNybble( block_data, blockIndex(x,y,z), value );
+	}
+
+	public void setBlock( int x, int y, int z, byte blockNum, byte extraBits ) {
+		setBlockNumber( x, y, z, blockNum );
+		setBlockExtraBits( x, y, z, extraBits );
+	}
+
+	public void setBlock( int x, int y, int z, byte blockNum ) {
+		setBlock( x, y, z, blockNum, (byte)0 );
+	}
+}

--- a/src/main/java/togos/minecraft/maprend/RegionMap.java
+++ b/src/main/java/togos/minecraft/maprend/RegionMap.java
@@ -31,16 +31,37 @@ public class RegionMap
 		if( r.rx >= maxX ) maxX = r.rx+1;
 		if( r.rz >= maxZ ) maxZ = r.rz+1;
 	}
-		
-	static final Pattern rfpat = Pattern.compile("^r\\.(-?\\d+)\\.(-?\\d+)\\.mca$");
-	
+
+	private void removeOldRegionFiles() {
+		int i = regions.size() - 1;
+		while( i >= 0 ) {
+			String path = regions.get(i).regionFile.getPath();
+			int len = path.length();
+			if( len > 4 && path.regionMatches(len - 4, ".mcr", 0, 4) ) {
+				regions.remove(i);
+				if(i < regions.size()) continue;
+			}
+			i--;
+		}
+	}
+
+	static final Pattern rfpat = Pattern.compile("^r\\.(-?[0-9]+)\\.(-?[0-9]+)\\.(mc[ar])$");
+	static final Pattern arfpat = Pattern.compile("^r\\.(-?[0-9]+)\\.(-?[0-9]+)\\.mca$");
+
 	protected void add( File dir, BoundingRect limit ) {
 		Matcher m;
 		if( dir.isDirectory() ) { 
+			boolean anvil_only = false;
 			File[] files = dir.listFiles();
 			for( int i=0; i<files.length; ++i ) {
-				m = rfpat.matcher(files[i].getName());
-				if( m.matches() ) add( files[i], limit );
+				m = (anvil_only ? arfpat : rfpat).matcher(files[i].getName());
+				if( m.matches() ) {
+					if( !anvil_only && m.group(3).equals("mca") ) {
+						anvil_only = true;
+						removeOldRegionFiles();
+					}
+					add( files[i], limit );
+				}
 			}
 		} else if( (m = rfpat.matcher(dir.getName())).matches() ) {
 			if( !dir.exists() ) {

--- a/src/main/java/togos/minecraft/maprend/io/RegionFile.java
+++ b/src/main/java/togos/minecraft/maprend/io/RegionFile.java
@@ -85,6 +85,7 @@ public class RegionFile
     private ArrayList<Boolean> sectorFree;
     private int sizeDelta;
     private long lastModified = 0;
+    private Boolean anvil_format;
 
     public RegionFile(File path) {
         offsets = new int[SECTOR_INTS];
@@ -248,7 +249,7 @@ public class RegionFile
 
     public DataOutputStream getChunkDataOutputStream(int x, int z) {
     	if (outOfBounds(x, z)) return null;
-    	
+
         return new DataOutputStream(new DeflaterOutputStream(getChunkOutputStream(x, z, VERSION_DEFLATE)));
     }
     
@@ -395,5 +396,15 @@ public class RegionFile
 
     public void close() throws IOException {
         file.close();
+    }
+
+    public boolean isAnvilFormat() {
+		if(anvil_format == null) {
+			String path = fileName.getPath();
+			boolean value = path.charAt(path.length() - 1) == 'a';
+			anvil_format = Boolean.valueOf(value);
+			return value;
+		}
+		return anvil_format.booleanValue();
     }
 }


### PR DESCRIPTION
This old region/chunk format is used by Minecraft Beta 1.3 and up to Minecraft 1.2; it is supported by early versions of TMCMR until commit 2294e4b.

This work has ported 2 classes back from commit 2014457 to support the old format. When searching regions in a directory, the old MCRegion format files will not be used if any Anvil format files are found.

I has used my forked version to render my Beta 1.6 world map, which is available at https://beijing.rivoreo.one:2037/b/